### PR TITLE
[PIDM-878] chore(infra): Add authorizer

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-mbd-service
 description: Microservice that handles services for eBollo
 type: application
-version: 0.109.0
-appVersion: 1.2.8
+version: 0.110.0
+appVersion: 1.2.8-1-PIDM-878
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-mbd-service
 description: Microservice that handles services for eBollo
 type: application
-version: 0.110.0
-appVersion: 1.2.8-1-PIDM-878
+version: 0.111.0
+appVersion: 1.2.8-2-PIDM-878
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-mbd-service"
   image:
     repository: ghcr.io/pagopa/pagopa-mbd-service
-    tag: "1.2.8"
+    tag: "1.2.8-1-PIDM-878"
     pullPolicy: Always
   livenessProbe:
     handlerType: httpGet

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-mbd-service"
   image:
     repository: ghcr.io/pagopa/pagopa-mbd-service
-    tag: "1.2.8-1-PIDM-878"
+    tag: "1.2.8-2-PIDM-878"
     pullPolicy: Always
   livenessProbe:
     handlerType: httpGet

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-mbd-service"
   image:
     repository: ghcr.io/pagopa/pagopa-mbd-service
-    tag: "1.2.8"
+    tag: "1.2.8-1-PIDM-878"
     pullPolicy: Always
   livenessProbe:
     handlerType: httpGet

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-mbd-service"
   image:
     repository: ghcr.io/pagopa/pagopa-mbd-service
-    tag: "1.2.8-1-PIDM-878"
+    tag: "1.2.8-2-PIDM-878"
     pullPolicy: Always
   livenessProbe:
     handlerType: httpGet

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-mbd-service"
   image:
     repository: ghcr.io/pagopa/pagopa-mbd-service
-    tag: "1.2.8"
+    tag: "1.2.8-1-PIDM-878"
     pullPolicy: Always
   livenessProbe:
     handlerType: httpGet

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: "pagopa-mbd-service"
   image:
     repository: ghcr.io/pagopa/pagopa-mbd-service
-    tag: "1.2.8-1-PIDM-878"
+    tag: "1.2.8-2-PIDM-878"
     pullPolicy: Always
   livenessProbe:
     handlerType: httpGet

--- a/infra/policy/_base_policy.xml
+++ b/infra/policy/_base_policy.xml
@@ -4,6 +4,17 @@
     <!-- rate limit by subscription key -->
     <rate-limit calls="300" renewal-period="10" remaining-calls-variable-name="remainingCallsPerSubscription"/>
     <set-backend-service base-url="https://${hostname}/pagopa-mbd-service"/>
+    <!-- Calling Authorizer's fragment -->
+    <set-variable name="application_domain" value="mbd" />
+    <set-variable name="metadata" value="no-metadata" />
+    <choose>
+        <!-- Making sure that will excludes all APIs that does not includes CI fiscal code -->
+        <when condition="@(context.Request.MatchedParameters.ContainsKey("fiscalCodeEC") && !context.Request.Headers.GetValueOrDefault(" Ocp-Apim-Subscription-Key", "").Equals(""))">
+          <set-variable name="authorization_entity" value="@(context.Request.MatchedParameters["fiscalCodeEC"])" />
+          <include-fragment fragment-id="authorizer" />
+          <include-fragment fragment-id="segregation-codes-gpd" />
+        </when>
+    </choose>
   </inbound>
   <outbound>
     <base/>

--- a/infra/policy/_base_policy.xml
+++ b/infra/policy/_base_policy.xml
@@ -9,7 +9,7 @@
     <set-variable name="metadata" value="no-metadata" />
     <choose>
         <!-- Making sure that will excludes all APIs that does not includes CI fiscal code -->
-        <when condition="@(context.Request.MatchedParameters.ContainsKey("fiscalCodeEC") && !context.Request.Headers.GetValueOrDefault(" Ocp-Apim-Subscription-Key", "").Equals(""))">
+        <when condition="@(context.Request.MatchedParameters.ContainsKey("fiscalCodeEC") && !context.Request.Headers.GetValueOrDefault("Ocp-Apim-Subscription-Key", "").Equals(""))">
           <set-variable name="authorization_entity" value="@(context.Request.MatchedParameters["fiscalCodeEC"])" />
           <include-fragment fragment-id="authorizer" />
           <include-fragment fragment-id="segregation-codes-gpd" />

--- a/integration-test/src/step_definitions/support/mdb_service_step.js
+++ b/integration-test/src/step_definitions/support/mdb_service_step.js
@@ -56,12 +56,12 @@ Then('response body contains checkoutUrl', function () {
 });
 
 Then('response contains mdb link', function () {
-  assert.notEqual(this.response?.data?.navDownloadLink, null);
+  assert.notEqual(this.response?.data?.mbdDownloadLink, null);
 });
 
 Then('response contains mdb nav', function () {
-  assert.notEqual(this.response?.data?.mbdNav, null);
-  this.correctNav = this.response?.data?.mbdNav;
+  assert.notEqual(this.response?.data?.nav, null);
+  this.correctNav = this.response?.data?.nav;
 });
 
 Given('a receipt of the former MDB payment being payed', async function () {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "mbd-service",
     "description": "MBD Service",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.2.8-1-PIDM-878"
+    "version": "1.2.8-2-PIDM-878"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,531 +1,492 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "mbd-service",
-    "description": "MBD Service",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.2.8"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "mbd-service",
+    "description" : "MBD Service",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "1.2.8"
   },
-  "servers": [
-    {
-      "url": "",
-      "description": "Generated server url"
-    }
-  ],
-  "paths": {
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "health check",
-        "description": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+  "servers" : [ {
+    "url" : "",
+    "description" : "Generated server url"
+  } ],
+  "paths" : {
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "health check",
+        "description" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{fiscalCodeEC}/mbd": {
-      "post": {
-        "tags": [
-          "mbd-controller"
-        ],
-        "summary": "getMbd",
-        "description": "Return mbd data for payment on requirement ",
-        "operationId": "getMdb",
-        "parameters": [
-          {
-            "name": "fiscalCodeEC",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{fiscalCodeEC}/mbd" : {
+      "post" : {
+        "tags" : [ "mbd-controller" ],
+        "summary" : "getMbd",
+        "description" : "Return mbd data for payment on requirement ",
+        "operationId" : "getMdb",
+        "parameters" : [ {
+          "name" : "fiscalCodeEC",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/GetMbdRequest"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/GetMbdRequest"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetCartResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/GetCartResponse"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "ibans for the brokerCode not found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "ibans for the brokerCode not found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetCartErrorResponse"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/GetCartErrorResponse"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     },
-    "/organizations/{fiscalCode}/receipt/{nav}": {
-      "get": {
-        "tags": [
-          "mbd-controller"
-        ],
-        "summary": "getPaymentReceipt",
-        "description": "Return receipt of payment on requirement ",
-        "operationId": "getPaymentReceipts",
-        "parameters": [
-          {
-            "name": "fiscalCode",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "nav",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{fiscalCodeEC}/receipt/{nav}" : {
+      "get" : {
+        "tags" : [ "mbd-controller" ],
+        "summary" : "getPaymentReceipt",
+        "description" : "Return receipt of payment on requirement ",
+        "operationId" : "getPaymentReceipts",
+        "parameters" : [ {
+          "name" : "fiscalCodeEC",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+        }, {
+          "name" : "nav",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetMdbReceipt"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/GetMdbReceipt"
                 }
               }
             }
           },
-          "400": {
-            "description": "Bad Request",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "400" : {
+            "description" : "Bad Request",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "401" : {
+            "description" : "Unauthorized",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/xml": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/xml" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "403" : {
+            "description" : "Forbidden",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "404": {
-            "description": "ibans for the brokerCode not found",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "404" : {
+            "description" : "ibans for the brokerCode not found",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "429" : {
+            "description" : "Too many requests",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "headers": {
-              "X-Request-Id": {
-                "description": "This header identifies the call",
-                "schema": {
-                  "type": "string"
+          "500" : {
+            "description" : "Service unavailable",
+            "headers" : {
+              "X-Request-Id" : {
+                "description" : "This header identifies the call",
+                "schema" : {
+                  "type" : "string"
                 }
               }
             },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "parameters": [
-        {
-          "name": "X-Request-Id",
-          "in": "header",
-          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-          "schema": {
-            "type": "string"
-          }
+      "parameters" : [ {
+        "name" : "X-Request-Id",
+        "in" : "header",
+        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+        "schema" : {
+          "type" : "string"
         }
-      ]
+      } ]
     }
   },
-  "components": {
-    "schemas": {
-      "GetMbdRequest": {
-        "required": [
-          "idCIService",
-          "returnUrls"
-        ],
-        "type": "object",
-        "properties": {
-          "paymentNotices": {
-            "maxItems": 1,
-            "minItems": 1,
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/PaymentNotice"
+  "components" : {
+    "schemas" : {
+      "GetMbdRequest" : {
+        "required" : [ "idCIService", "returnUrls" ],
+        "type" : "object",
+        "properties" : {
+          "paymentNotices" : {
+            "maxItems" : 1,
+            "minItems" : 1,
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PaymentNotice"
             }
           },
-          "idCIService": {
-            "type": "string"
+          "idCIService" : {
+            "type" : "string"
           },
-          "returnUrls": {
-            "$ref": "#/components/schemas/ReturnUrls"
+          "returnUrls" : {
+            "$ref" : "#/components/schemas/ReturnUrls"
           }
         }
       },
-      "PaymentNotice": {
-        "required": [
-          "amount",
-          "email",
-          "firstName",
-          "fiscalCode",
-          "lastName",
-          "province"
-        ],
-        "type": "object",
-        "properties": {
-          "firstName": {
-            "type": "string"
+      "PaymentNotice" : {
+        "required" : [ "amount", "email", "firstName", "fiscalCode", "lastName", "province" ],
+        "type" : "object",
+        "properties" : {
+          "firstName" : {
+            "type" : "string"
           },
-          "lastName": {
-            "type": "string"
+          "lastName" : {
+            "type" : "string"
           },
-          "fiscalCode": {
-            "type": "string"
+          "fiscalCode" : {
+            "type" : "string"
           },
-          "email": {
-            "type": "string"
+          "email" : {
+            "type" : "string"
           },
-          "amount": {
-            "type": "integer",
-            "format": "int64"
+          "amount" : {
+            "type" : "integer",
+            "format" : "int64"
           },
-          "province": {
-            "type": "string"
+          "province" : {
+            "type" : "string"
           },
-          "documentHash": {
-            "maxLength": 44,
-            "minLength": 44,
-            "type": "string"
+          "documentHash" : {
+            "maxLength" : 44,
+            "minLength" : 44,
+            "type" : "string"
           }
         }
       },
-      "ReturnUrls": {
-        "required": [
-          "cancelUrl",
-          "errorUrl",
-          "successUrl"
-        ],
-        "type": "object",
-        "properties": {
-          "successUrl": {
-            "type": "string"
+      "ReturnUrls" : {
+        "required" : [ "cancelUrl", "errorUrl", "successUrl" ],
+        "type" : "object",
+        "properties" : {
+          "successUrl" : {
+            "type" : "string"
           },
-          "cancelUrl": {
-            "type": "string"
+          "cancelUrl" : {
+            "type" : "string"
           },
-          "errorUrl": {
-            "type": "string"
+          "errorUrl" : {
+            "type" : "string"
           }
         }
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "GetCartResponse": {
-        "type": "object",
-        "properties": {
-          "checkoutRedirectUrl": {
-            "type": "string"
-          },
-          "navDownloadLink": {
-            "type": "string"
-          },
-          "mbdNav": {
-            "type": "string"
+      "GetCartErrorResponse" : {
+        "type" : "object",
+        "properties" : {
+          "errorUrl" : {
+            "type" : "string"
           }
         }
       },
-      "GetCartErrorResponse": {
-        "type": "object",
-        "properties": {
-          "errorUrl": {
-            "type": "string"
+      "GetCartResponse" : {
+        "type" : "object",
+        "properties" : {
+          "checkoutRedirectUrl" : {
+            "type" : "string"
+          },
+          "navDownloadLink" : {
+            "type" : "string"
+          },
+          "mbdNav" : {
+            "type" : "string"
           }
         }
       },
-      "GetMdbReceipt": {
-        "type": "object",
-        "properties": {
-          "content": {
-            "type": "array",
-            "items": {
-              "type": "string",
-              "format": "byte"
+      "GetMdbReceipt" : {
+        "type" : "object",
+        "properties" : {
+          "content" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "format" : "byte"
             }
           }
         }
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
+          "version" : {
+            "type" : "string"
           },
-          "environment": {
-            "type": "string"
+          "environment" : {
+            "type" : "string"
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       }
     }
   }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,492 +1,531 @@
 {
-  "openapi" : "3.0.1",
-  "info" : {
-    "title" : "mbd-service",
-    "description" : "MBD Service",
-    "termsOfService" : "https://www.pagopa.gov.it/",
-    "version" : "1.2.8"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "mbd-service",
+    "description": "MBD Service",
+    "termsOfService": "https://www.pagopa.gov.it/",
+    "version": "1.2.8-1-PIDM-878"
   },
-  "servers" : [ {
-    "url" : "",
-    "description" : "Generated server url"
-  } ],
-  "paths" : {
-    "/info" : {
-      "get" : {
-        "tags" : [ "Home" ],
-        "summary" : "health check",
-        "description" : "Return OK if application is started",
-        "operationId" : "healthCheck",
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+  "servers": [
+    {
+      "url": "",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/info": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "health check",
+        "description": "Return OK if application is started",
+        "operationId": "healthCheck",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "*/*" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AppInfo"
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{fiscalCodeEC}/mbd" : {
-      "post" : {
-        "tags" : [ "mbd-controller" ],
-        "summary" : "getMbd",
-        "description" : "Return mbd data for payment on requirement ",
-        "operationId" : "getMdb",
-        "parameters" : [ {
-          "name" : "fiscalCodeEC",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/GetMbdRequest"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/GetCartResponse"
-                }
-              }
-            }
-          },
-          "400" : {
-            "description" : "Bad Request",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "404" : {
-            "description" : "ibans for the brokerCode not found",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "429" : {
-            "description" : "Too many requests",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            }
-          },
-          "500" : {
-            "description" : "Service unavailable",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
-                }
-              }
-            },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/GetCartErrorResponse"
-                }
-              }
+    "/organizations/{fiscalCodeEC}/mbd": {
+      "post": {
+        "tags": [
+          "mbd-controller"
+        ],
+        "summary": "getMbd",
+        "description": "Return mbd data for payment on requirement ",
+        "operationId": "getMdb",
+        "parameters": [
+          {
+            "name": "fiscalCodeEC",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetMbdRequest"
+              }
+            }
+          },
+          "required": true
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCartResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "ibans for the brokerCode not found",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Service unavailable",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetCartErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     },
-    "/organizations/{fiscalCodeEC}/receipt/{nav}" : {
-      "get" : {
-        "tags" : [ "mbd-controller" ],
-        "summary" : "getPaymentReceipt",
-        "description" : "Return receipt of payment on requirement ",
-        "operationId" : "getPaymentReceipts",
-        "parameters" : [ {
-          "name" : "fiscalCodeEC",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/{fiscalCodeEC}/receipt/{nav}": {
+      "get": {
+        "tags": [
+          "mbd-controller"
+        ],
+        "summary": "getPaymentReceipt",
+        "description": "Return receipt of payment on requirement ",
+        "operationId": "getPaymentReceipts",
+        "parameters": [
+          {
+            "name": "fiscalCodeEC",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nav",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        }, {
-          "name" : "nav",
-          "in" : "path",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/GetMdbReceipt"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetMdbReceipt"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "400": {
+            "description": "Bad Request",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "401": {
+            "description": "Unauthorized",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/xml" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "403": {
+            "description": "Forbidden",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "404" : {
-            "description" : "ibans for the brokerCode not found",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "404": {
+            "description": "ibans for the brokerCode not found",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429" : {
-            "description" : "Too many requests",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "429": {
+            "description": "Too many requests",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "headers" : {
-              "X-Request-Id" : {
-                "description" : "This header identifies the call",
-                "schema" : {
-                  "type" : "string"
+          "500": {
+            "description": "Service unavailable",
+            "headers": {
+              "X-Request-Id": {
+                "description": "This header identifies the call",
+                "schema": {
+                  "type": "string"
                 }
               }
             },
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "parameters" : [ {
-        "name" : "X-Request-Id",
-        "in" : "header",
-        "description" : "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
-        "schema" : {
-          "type" : "string"
+      "parameters": [
+        {
+          "name": "X-Request-Id",
+          "in": "header",
+          "description": "This header identifies the call, if not passed it is self-generated. This ID is returned in the response.",
+          "schema": {
+            "type": "string"
+          }
         }
-      } ]
+      ]
     }
   },
-  "components" : {
-    "schemas" : {
-      "GetMbdRequest" : {
-        "required" : [ "idCIService", "returnUrls" ],
-        "type" : "object",
-        "properties" : {
-          "paymentNotices" : {
-            "maxItems" : 1,
-            "minItems" : 1,
-            "type" : "array",
-            "items" : {
-              "$ref" : "#/components/schemas/PaymentNotice"
+  "components": {
+    "schemas": {
+      "GetMbdRequest": {
+        "required": [
+          "idCIService",
+          "returnUrls"
+        ],
+        "type": "object",
+        "properties": {
+          "paymentNotices": {
+            "maxItems": 1,
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentNotice"
             }
           },
-          "idCIService" : {
-            "type" : "string"
+          "idCIService": {
+            "type": "string"
           },
-          "returnUrls" : {
-            "$ref" : "#/components/schemas/ReturnUrls"
+          "returnUrls": {
+            "$ref": "#/components/schemas/ReturnUrls"
           }
         }
       },
-      "PaymentNotice" : {
-        "required" : [ "amount", "email", "firstName", "fiscalCode", "lastName", "province" ],
-        "type" : "object",
-        "properties" : {
-          "firstName" : {
-            "type" : "string"
+      "PaymentNotice": {
+        "required": [
+          "amount",
+          "email",
+          "firstName",
+          "fiscalCode",
+          "lastName",
+          "province"
+        ],
+        "type": "object",
+        "properties": {
+          "firstName": {
+            "type": "string"
           },
-          "lastName" : {
-            "type" : "string"
+          "lastName": {
+            "type": "string"
           },
-          "fiscalCode" : {
-            "type" : "string"
+          "fiscalCode": {
+            "type": "string"
           },
-          "email" : {
-            "type" : "string"
+          "email": {
+            "type": "string"
           },
-          "amount" : {
-            "type" : "integer",
-            "format" : "int64"
+          "amount": {
+            "type": "integer",
+            "format": "int64"
           },
-          "province" : {
-            "type" : "string"
+          "province": {
+            "type": "string"
           },
-          "documentHash" : {
-            "maxLength" : 44,
-            "minLength" : 44,
-            "type" : "string"
+          "documentHash": {
+            "maxLength": 44,
+            "minLength": 44,
+            "type": "string"
           }
         }
       },
-      "ReturnUrls" : {
-        "required" : [ "cancelUrl", "errorUrl", "successUrl" ],
-        "type" : "object",
-        "properties" : {
-          "successUrl" : {
-            "type" : "string"
+      "ReturnUrls": {
+        "required": [
+          "cancelUrl",
+          "errorUrl",
+          "successUrl"
+        ],
+        "type": "object",
+        "properties": {
+          "successUrl": {
+            "type": "string"
           },
-          "cancelUrl" : {
-            "type" : "string"
+          "cancelUrl": {
+            "type": "string"
           },
-          "errorUrl" : {
-            "type" : "string"
+          "errorUrl": {
+            "type": "string"
           }
         }
       },
-      "ProblemJson" : {
-        "type" : "object",
-        "properties" : {
-          "title" : {
-            "type" : "string",
-            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status" : {
-            "maximum" : 600,
-            "minimum" : 100,
-            "type" : "integer",
-            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format" : "int32",
-            "example" : 200
+          "status": {
+            "maximum": 600,
+            "minimum": 100,
+            "type": "integer",
+            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format": "int32",
+            "example": 200
           },
-          "detail" : {
-            "type" : "string",
-            "description" : "A human readable explanation specific to this occurrence of the problem.",
-            "example" : "There was an error processing the request"
+          "detail": {
+            "type": "string",
+            "description": "A human readable explanation specific to this occurrence of the problem.",
+            "example": "There was an error processing the request"
           }
         }
       },
-      "GetCartErrorResponse" : {
-        "type" : "object",
-        "properties" : {
-          "errorUrl" : {
-            "type" : "string"
+      "GetCartErrorResponse": {
+        "type": "object",
+        "properties": {
+          "errorUrl": {
+            "type": "string"
           }
         }
       },
-      "GetCartResponse" : {
-        "type" : "object",
-        "properties" : {
-          "checkoutRedirectUrl" : {
-            "type" : "string"
+      "GetCartResponse": {
+        "type": "object",
+        "properties": {
+          "checkoutRedirectUrl": {
+            "type": "string"
           },
-          "navDownloadLink" : {
-            "type" : "string"
+          "navDownloadLink": {
+            "type": "string"
           },
-          "mbdNav" : {
-            "type" : "string"
+          "mbdNav": {
+            "type": "string"
           }
         }
       },
-      "GetMdbReceipt" : {
-        "type" : "object",
-        "properties" : {
-          "content" : {
-            "type" : "array",
-            "items" : {
-              "type" : "string",
-              "format" : "byte"
+      "GetMdbReceipt": {
+        "type": "object",
+        "properties": {
+          "content": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "byte"
             }
           }
         }
       },
-      "AppInfo" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "AppInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "version" : {
-            "type" : "string"
+          "version": {
+            "type": "string"
           },
-          "environment" : {
-            "type" : "string"
+          "environment": {
+            "type": "string"
           }
         }
       }
     },
-    "securitySchemes" : {
-      "ApiKey" : {
-        "type" : "apiKey",
-        "description" : "The API key to access this function app.",
-        "name" : "Ocp-Apim-Subscription-Key",
-        "in" : "header"
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "The API key to access this function app.",
+        "name": "Ocp-Apim-Subscription-Key",
+        "in": "header"
       }
     }
   }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -8,8 +8,23 @@
   },
   "servers": [
     {
-      "url": "",
-      "description": "Generated server url"
+      "url": "http://localhost:8080"
+    },
+    {
+      "url": "https://{host}{basePath}",
+      "variables": {
+        "host": {
+          "default": "api.dev.platform.pagopa.it",
+          "enum": [
+            "api.dev.platform.pagopa.it",
+            "api.uat.platform.pagopa.it",
+            "api.platform.pagopa.it"
+          ]
+        },
+        "basePath": {
+          "default": "/pagopa-mbd-service/v1"
+        }
+      }
     }
   ],
   "paths": {
@@ -449,6 +464,14 @@
           }
         }
       },
+      "GetCartErrorResponse": {
+        "type": "object",
+        "properties": {
+          "errorUrl": {
+            "type": "string"
+          }
+        }
+      },
       "GetCartResponse": {
         "type": "object",
         "properties": {
@@ -482,14 +505,6 @@
             "type": "string",
             "description": "A human readable explanation specific to this occurrence of the problem.",
             "example": "There was an error processing the request"
-          }
-        }
-      },
-      "GetCartErrorResponse": {
-        "type": "object",
-        "properties": {
-          "errorUrl": {
-            "type": "string"
           }
         }
       },

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -449,6 +449,20 @@
           }
         }
       },
+      "GetCartResponse": {
+        "type": "object",
+        "properties": {
+          "checkoutRedirectUrl": {
+            "type": "string"
+          },
+          "mbdDownloadLink": {
+            "type": "string"
+          },
+          "nav": {
+            "type": "string"
+          }
+        }
+      },
       "ProblemJson": {
         "type": "object",
         "properties": {
@@ -475,20 +489,6 @@
         "type": "object",
         "properties": {
           "errorUrl": {
-            "type": "string"
-          }
-        }
-      },
-      "GetCartResponse": {
-        "type": "object",
-        "properties": {
-          "checkoutRedirectUrl": {
-            "type": "string"
-          },
-          "navDownloadLink": {
-            "type": "string"
-          },
-          "mbdNav": {
             "type": "string"
           }
         }

--- a/performance-test/src/scripts/pre_condition_script.js
+++ b/performance-test/src/scripts/pre_condition_script.js
@@ -15,7 +15,7 @@ const createPositionForReceipt = async () => {
       "idReceipt": this.response?.data?.idReceipt,
       "fee": this.response?.data?.fee
     }
-    await payReceipt(fiscalCodeEC, this.responseMDB?.data?.mbdNav, payBody);
+    await payReceipt(fiscalCodeEC, this.responseMDB?.data?.nav, payBody);
 
 
 };

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>it.gov.pagopa.ebollo</groupId>
   <artifactId>mbd-service</artifactId>
-  <version>1.2.8</version>
+  <version>1.2.8-1-PIDM-878</version>
   <name>MBD Service</name>
   <description>MBD Service</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <groupId>it.gov.pagopa.ebollo</groupId>
   <artifactId>mbd-service</artifactId>
-  <version>1.2.8-1-PIDM-878</version>
+  <version>1.2.8-2-PIDM-878</version>
   <name>MBD Service</name>
   <description>MBD Service</description>
 

--- a/src/main/java/it/gov/pagopa/mbd/service/config/OpenApiConfig.java
+++ b/src/main/java/it/gov/pagopa/mbd/service/config/OpenApiConfig.java
@@ -11,15 +11,14 @@ import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.servers.ServerVariable;
+import io.swagger.v3.oas.models.servers.ServerVariables;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-
-import io.swagger.v3.oas.models.servers.Server;
-import io.swagger.v3.oas.models.servers.ServerVariable;
-import io.swagger.v3.oas.models.servers.ServerVariables;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -28,7 +27,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OpenApiConfig {
 
-    public static final String BASE_PATH = "/pagopa-mbd-service/v1";
+  public static final String BASE_PATH = "/pagopa-mbd-service/v1";
 
   @Bean
   public OpenAPI customOpenAPI(
@@ -36,14 +35,24 @@ public class OpenApiConfig {
       @Value("${info.application.description}") String appDescription,
       @Value("${info.application.version}") String appVersion) {
     return new OpenAPI()
-                .servers(List.of(new Server().url("http://localhost:8080"),
-                        new Server().url("https://{host}{basePath}")
-                                .variables(new ServerVariables()
-                                        .addServerVariable("host",
-                                                new ServerVariable()._enum(List.of("api.dev.platform.pagopa.it", "api.uat.platform.pagopa.it", "api.platform.pagopa.it"))
-                                                        ._default("api.dev.platform.pagopa.it"))
-                                        .addServerVariable("basePath", new ServerVariable()._default(BASE_PATH))
-                                )))
+        .servers(
+            List.of(
+                new Server().url("http://localhost:8080"),
+                new Server()
+                    .url("https://{host}{basePath}")
+                    .variables(
+                        new ServerVariables()
+                            .addServerVariable(
+                                "host",
+                                new ServerVariable()
+                                    ._enum(
+                                        List.of(
+                                            "api.dev.platform.pagopa.it",
+                                            "api.uat.platform.pagopa.it",
+                                            "api.platform.pagopa.it"))
+                                    ._default("api.dev.platform.pagopa.it"))
+                            .addServerVariable(
+                                "basePath", new ServerVariable()._default(BASE_PATH)))))
         .components(
             new Components()
                 .addSecuritySchemes(

--- a/src/main/java/it/gov/pagopa/mbd/service/config/OpenApiConfig.java
+++ b/src/main/java/it/gov/pagopa/mbd/service/config/OpenApiConfig.java
@@ -12,9 +12,14 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+
+import io.swagger.v3.oas.models.servers.Server;
+import io.swagger.v3.oas.models.servers.ServerVariable;
+import io.swagger.v3.oas.models.servers.ServerVariables;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -23,12 +28,22 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class OpenApiConfig {
 
+    public static final String BASE_PATH = "/pagopa-mbd-service/v1";
+
   @Bean
   public OpenAPI customOpenAPI(
       @Value("${info.application.artifactId}") String appName,
       @Value("${info.application.description}") String appDescription,
       @Value("${info.application.version}") String appVersion) {
     return new OpenAPI()
+                .servers(List.of(new Server().url("http://localhost:8080"),
+                        new Server().url("https://{host}{basePath}")
+                                .variables(new ServerVariables()
+                                        .addServerVariable("host",
+                                                new ServerVariable()._enum(List.of("api.dev.platform.pagopa.it", "api.uat.platform.pagopa.it", "api.platform.pagopa.it"))
+                                                        ._default("api.dev.platform.pagopa.it"))
+                                        .addServerVariable("basePath", new ServerVariable()._default(BASE_PATH))
+                                )))
         .components(
             new Components()
                 .addSecuritySchemes(

--- a/src/main/java/it/gov/pagopa/mbd/service/controller/MbdController.java
+++ b/src/main/java/it/gov/pagopa/mbd/service/controller/MbdController.java
@@ -155,10 +155,10 @@ public class MbdController {
                     schema = @Schema(implementation = ProblemJson.class)))
       })
   @GetMapping(
-      value = "/organizations/{fiscalCode}/receipt/{nav}",
+      value = "/organizations/{fiscalCodeEC}/receipt/{nav}",
       produces = MediaType.APPLICATION_XML_VALUE)
   public Mono<ResponseEntity> getPaymentReceipts(
-      @PathVariable("fiscalCode") String fiscalCode, @PathVariable("nav") String nav) {
+      @PathVariable("fiscalCodeEC") String fiscalCode, @PathVariable("nav") String nav) {
     return mdbService.getPaymentReceipts(fiscalCode, nav).onErrorResume(Mono::error);
   }
 }

--- a/src/main/java/it/gov/pagopa/mbd/service/model/carts/GetCartResponse.java
+++ b/src/main/java/it/gov/pagopa/mbd/service/model/carts/GetCartResponse.java
@@ -13,7 +13,7 @@ public class GetCartResponse {
 
   private String checkoutRedirectUrl;
 
-  private String navDownloadLink;
+  private String mbdDownloadLink;
 
-  private String mbdNav;
+  private String nav;
 }

--- a/src/main/java/it/gov/pagopa/mbd/service/service/impl/MbdServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/mbd/service/service/impl/MbdServiceImpl.java
@@ -120,8 +120,8 @@ public class MbdServiceImpl implements MbdService {
             item -> {
               String noticeNumber =
                   hashMap.get("demandPaymentNoticeResponse").getQrCode().getNoticeNumber();
-              item.setMbdNav(noticeNumber);
-              item.setNavDownloadLink(
+              item.setNav(noticeNumber);
+              item.setMbdDownloadLink(
                   StringUtils.joinWith(
                       "/", mdbLinkBaseUrl, "organizations", fiscalCodeEC, "receipt", noticeNumber));
               return ResponseEntity.ok().header(CONTENT_TYPE, APPLICATION_JSON_VALUE).body(item);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Policy update to call authorizer fragment with `fiscalCodeEC` as input.
- `fiscalCode` param in `getPaymentReceipts` API was been renamed in `fiscalCodeEC` in swagger documentation.
- fixed response body field names

#### Motivation and Context
[PIDM-878](https://pagopa.atlassian.net/browse/PIDM-878)
<!--- Why is this change required? What problem does it solve? -->

- Authorization management by organization fiscal code.

Align implementation with Design Review
#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


[PIDM-878]: https://pagopa.atlassian.net/browse/PIDM-878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ